### PR TITLE
refactor(arch): make CpuContext opaque, move MIPS definition to impl

### DIFF
--- a/arch/include/arch_cpu.h
+++ b/arch/include/arch_cpu.h
@@ -4,41 +4,7 @@
 #include <stdint.h>
 
 /* ===== Tipi ===== */
-typedef struct CpuContext {
-    uint32_t ra; //offset 0
-    uint32_t sp; //offset 4
-    uint32_t gp; //offset 8
-    uint32_t s0; //offset 12
-    uint32_t s1; //offset 16
-    uint32_t s2; //offset 20
-    uint32_t s3; //offset 24
-    uint32_t s4; //offset 28
-    uint32_t s5; //offset 32
-    uint32_t s6; //offset 36
-    uint32_t s7; //offset 40
-    uint32_t a0; //offset 44
-    uint32_t a1; //offset 48
-    uint32_t a2; //offset 52
-    uint32_t a3; //offset 56
-    uint32_t status; //offset 60 
-    uint32_t epc; //offset 64
-    uint32_t fp; //offset 68
-    uint32_t v0; // offset 72
-    uint32_t v1; // offset 76
-    uint32_t at; // offset 80
-    uint32_t t0; //offset 84
-    uint32_t t1; //offset 88
-    uint32_t t2; //offset 92
-    uint32_t t3; //offset 96
-    uint32_t t4; //offset 100
-    uint32_t t5; //offset 104
-    uint32_t t6; //offset 108
-    uint32_t t7; //offset 112
-    uint32_t t8; //offset 116
-    uint32_t t9; //offset 120
-    uint32_t hi; //offset 124
-    uint32_t lo; //offset 128
-} CpuContext;
+typedef struct CpuContext CpuContext;
 
 /* ===== Context ===== */
 void cpu_context_save(CpuContext *ctx);

--- a/arch/mips/impl/pic32mx_cpu.c
+++ b/arch/mips/impl/pic32mx_cpu.c
@@ -1,4 +1,5 @@
 #include "arch/arch.h"
+#include "pic32mx_cpu.h"
 #include "arch/include/arch_cpu.h"
 #include <stddef.h>
 /* =====================================================================================

--- a/arch/mips/impl/pic32mx_cpu.h
+++ b/arch/mips/impl/pic32mx_cpu.h
@@ -1,0 +1,44 @@
+#ifndef PIC32MX_CPU_H
+#define PIC32MX_CPU_H
+
+#include <stdint.h>
+
+typedef struct CpuContext {
+    uint32_t ra; //offset 0
+    uint32_t sp; //offset 4
+    uint32_t gp; //offset 8
+    uint32_t s0; //offset 12
+    uint32_t s1; //offset 16
+    uint32_t s2; //offset 20
+    uint32_t s3; //offset 24
+    uint32_t s4; //offset 28
+    uint32_t s5; //offset 32
+    uint32_t s6; //offset 36
+    uint32_t s7; //offset 40
+    uint32_t a0; //offset 44
+    uint32_t a1; //offset 48
+    uint32_t a2; //offset 52
+    uint32_t a3; //offset 56
+    uint32_t status; //offset 60 
+    uint32_t epc; //offset 64
+    uint32_t fp; //offset 68
+    uint32_t v0; // offset 72
+    uint32_t v1; // offset 76
+    uint32_t at; // offset 80
+    uint32_t t0; //offset 84
+    uint32_t t1; //offset 88
+    uint32_t t2; //offset 92
+    uint32_t t3; //offset 96
+    uint32_t t4; //offset 100
+    uint32_t t5; //offset 104
+    uint32_t t6; //offset 108
+    uint32_t t7; //offset 112
+    uint32_t t8; //offset 116
+    uint32_t t9; //offset 120
+    uint32_t hi; //offset 124
+    uint32_t lo; //offset 128
+} CpuContext;
+
+
+
+#endif

--- a/kernel/scheduler/task.h
+++ b/kernel/scheduler/task.h
@@ -15,6 +15,7 @@
 #ifndef TASK_H
 #define TASK_H
 
+#include "../../arch/mips/impl/pic32mx_cpu.h"
 #include "arch/include/arch_cpu.h"
 #include <stdint.h>
 


### PR DESCRIPTION
- Remove concrete CpuContext structure from arch/include/arch_cpu.h
- Add opaque typedef in public header
- Create arch/mips/pic32mx_cpu.h with MIPS-specific structure
- Update pic32mx_cpu.c to include new private header
- Update task.h to include new private header

Closes #3