### PR TITLE
- Add total_cycles (uint64_t) and last_count (uint32_t) to Task struct

### DIFF
--- a/arch/include/arch_systick.h
+++ b/arch/include/arch_systick.h
@@ -1,0 +1,112 @@
+/**
+ * @file arch_systick.h
+ * @author Santiago Marino
+ * @year 2026
+ * @brief Abstraction for system tick timer (scheduler tick source).
+ * 
+ * This file provides an opaque interface to the architecture-specific
+ * timer that generates periodic interrupts for the scheduler.
+ */
+
+#ifndef ARCH_SYSTICK_H
+#define ARCH_SYSTICK_H
+
+#include <stdint.h>
+
+/**
+ * @brief Opaque type - concrete definition is architecture-specific.
+ */
+typedef struct ArchSysTick ArchSysTick;
+
+/**
+ * @brief Get the global system tick timer instance.
+ * 
+ * @return Pointer to the singleton ArchSysTick instance
+ */
+ArchSysTick* arch_systick_get_instance(void);
+
+/**
+ * @brief Read the current counter value.
+ * 
+ * @param tick Pointer to ArchSysTick instance
+ * @return Current counter value (in timer ticks)
+ */
+uint32_t arch_systick_read(const ArchSysTick *tick);
+
+/**
+ * @brief Get the current compare/period value.
+ * 
+ * @param tick Pointer to ArchSysTick instance
+ * @return Compare/period value in ticks
+ */
+uint32_t arch_systick_get_period(const ArchSysTick *tick);
+
+/**
+ * @brief Get the timer frequency in Hz.
+ * 
+ * @param tick Pointer to ArchSysTick instance
+ * @return Frequency in Hz
+ */
+uint32_t arch_systick_get_frequency(const ArchSysTick *tick);
+
+/**
+ * @brief Initialize the system tick timer.
+ * 
+ * @param tick Pointer to ArchSysTick instance
+ * @param period_cycles Number of cycles between interrupts
+ * @return 0 on success, -1 on error
+ */
+int arch_systick_init(ArchSysTick *tick, uint32_t period_cycles);
+
+/**
+ * @brief Set the timer period.
+ * 
+ * IMPORTANT: Increments Compare, does NOT reset Count.
+ * This preserves ability to measure elapsed time across interrupts.
+ * 
+ * @param tick Pointer to ArchSysTick instance
+ * @param period_cycles New period in cycles
+ */
+void arch_systick_set_period(ArchSysTick *tick, uint32_t period_cycles);
+
+/**
+ * @brief Enable the system tick interrupt.
+ * 
+ * @param tick Pointer to ArchSysTick instance
+ */
+void arch_systick_enable_interrupt(ArchSysTick *tick);
+
+/**
+ * @brief Clear the interrupt flag.
+ * 
+ * Must be called in the interrupt handler before returning.
+ * 
+ * @param tick Pointer to ArchSysTick instance
+ */
+void arch_systick_clear_interrupt(ArchSysTick *tick);
+
+/**
+ * @brief Start the timer.
+ * 
+ * @param tick Pointer to ArchSysTick instance
+ */
+void arch_systick_start(ArchSysTick *tick);
+
+/**
+ * @brief Stop the timer (disable interrupt).
+ * 
+ * @param tick Pointer to ArchSysTick instance
+ */
+void arch_systick_stop(ArchSysTick *tick);
+
+/**
+ * @brief Tick handler - called from ISR.
+ * 
+ * Increments Compare register by period instead of resetting Count.
+ * This function must be called from the architecture-specific ISR.
+ * 
+ * @param tick Pointer to ArchSysTick instance
+ */
+void arch_systick_tick(ArchSysTick *tick);
+
+#endif /* ARCH_SYSTICK_H */

--- a/arch/mips/core_timer_isr.S
+++ b/arch/mips/core_timer_isr.S
@@ -11,19 +11,23 @@
 
 .global core_timer_isr
 .ent core_timer_isr
+
 core_timer_isr:
     /* 1. Puntiamo al TCB (Task Control Block) usando k0 */
     la      $k0, current_task
-    lw      $k0, 0($k0)          # k0 = indirizzo CpuContext del task corrente
+    lw	    $k0, 0($k0)		    # $k0 = current_task (Task*)
+#    lw      $k0, 0($k0)		    # $k0 = current_task->context (CpuContext*)
     
     # Se il puntatore è NULL (avvio sistema), saltiamo il salvataggio
     beqz    $k0, setup_kernel_stack
     nop
     nop
     nop
-    
 
     /* 2. SALVATAGGIO CONTESTO (32 registri + Speciali) */
+   # la      $k0, current_task	    # se siamo arrivati qui è perche current_task
+   # lw	    $k0, 0($k0)		    # $k0 = current_task (Task*)
+    lw      $k0, 0($k0)		    # $k0 = current_task->context (CpuContext*)
     sw      $ra,  0($k0)
     sw      $sp,  4($k0)         # SP originale del task
     sw      $gp,  8($k0)
@@ -62,27 +66,15 @@ core_timer_isr:
     nop
     nop
     nop
-    
     sw      $k1, 128($k0)
 
     # Status: salviamo ESATTAMENTE lo stato corrente (incluso EXL=1)
-    # NON dobbiamo modificarlo: eret si occuperà di ripristinare lo stato corretto
-
     mfc0    $k1, $12
     ehb
     nop
     nop
     nop
-    
     sw      $k1, 60($k0)
-    
-
-//    # Status: salviamo lo stato pulendo i bit di eccezione
-//    mfc0    $k1, $12
-//    li      $t0, STATUS_CLEAR_MASK
-//    and     $k1, $k1, $t0
-//    ori     $k1, $k1, 0x1        # Forza IE=1 per il rientro
-//    sw      $k1, 60($k0)
 
     # EPC: Indirizzo di rientro del task
     mfc0    $k1, $14
@@ -90,7 +82,6 @@ core_timer_isr:
     nop
     nop
     nop
-    
     sw      $k1, 64($k0)
 
 setup_kernel_stack:
@@ -98,23 +89,34 @@ setup_kernel_stack:
     la      $k1, kernel_stack
     addiu   $sp, $k1, KERNEL_STACK_SIZE - 16
 
-    /* 4. Reset del flag interrupt (Metodo Atomico) */
-    # Scriviamo 1 (maschera bit 0) nel registro CLR (0x1034)
+    /* 4. Pulisci il flag interrupt (IFS0CLR) */
     li      $k1, (1 << CTIF_BIT)
     la      $k0, IFS0CLR
-    sw      $k1, 0($k0)          
+    sw      $k1, 0($k0)
 
-    /* 5. Chiamata allo Scheduler C */
+    /* 5. NUOVO: Incrementa Compare invece di resettare Count
+     *    Chiama arch_systick_get_instance() per ottenere il puntatore
+     *    Poi chiama arch_systick_tick() per incrementare Compare
+     *    Questa è la chiave per la misurazione del CPU usage
+     */
+    jal     arch_systick_get_instance
+    nop
+    move    $a0, $v0              # $a0 = puntatore a ArchSysTick
+    jal     arch_systick_tick
+    nop
+
+    /* 6. Chiamata allo Scheduler C (timer_callback) */
     jal     timer_callback
     ehb
     nop
     nop
     nop
 
-    /* 6. Salto al ripristino (Tail-Call) */
-    la      $a0, current_task
-    lw      $a0, 0($a0)          # Carica il TCB scelto
-    
-    j       cpu_context_restore  
-    nop
+//    /* 7. Salto al ripristino (Tail-Call) */
+//    la      $a0, current_task
+//    lw      $a0, 0($a0)          # Carica il TCB scelto
+//lw      $a0, 0($a0)          # $a0 = current_task->context (CpuContext*)    
+//    j       cpu_context_restore  
+//    nop
+
 .end core_timer_isr

--- a/arch/mips/impl/harmony/core_timer_impl.c
+++ b/arch/mips/impl/harmony/core_timer_impl.c
@@ -1,52 +1,25 @@
 #include "arch/arch_core_timer.h"
+#include "arch/include/arch_systick.h"
 
 #if defined(__32MX470F512H_HARMONY__)
-#include <xc.h>               /* definisce i registri CP0 e i nomi simbolici */
+#include <xc.h>
 
-#include "peripheral/coretimer/plib_coretimer.h"
-
-void arch_core_timer_impl_init(void) {
-    CORETIMER_Initialize();
-    /* Imposta il periodo: scrivi 0xFA00 nel registro Compare (CP0 $11) */
-
-
-    /* (Opzionale) Azzera il contatore (CP0 $9) */
-    __asm__ volatile (
-        "mtc0 $zero, $9\n"
-    
-    
-    );   
-    
-//    __asm__ volatile (
-//        "mtc0 $zero, $12, 1\n"    /*SRSCtl (CP0 register 12, select 1)*/
-//        "mtc0 $zero, $12, 2\n"   /* # SRSMap (CP0 register 12, select 2)*/
-//    );
-    
-    CORETIMER_Start();
-        __asm__ volatile (
-        "li   $t0, 0xFFA00\n"
-        "mtc0 $t0, $11\n"
-        : : : "t0"
-    );
+void arch_core_timer_impl_init(void)
+{
+    ArchSysTick *systick = arch_systick_get_instance();
+    uint32_t period_cycles = 400000;
+    arch_systick_init(systick, period_cycles);
 }
 
-void arch_core_timer_impl_set_callback(arch_core_timer_cb_t callback, uintptr_t context) {
-//    CORETIMER_CallbackSet(callback, context);
+void arch_core_timer_impl_set_callback(arch_core_timer_cb_t callback, uintptr_t context)
+{
+    /* Non usato */
 }
 
-
-/* Abilita l'interrupt del core timer (senza usare Harmony) */
-void arch_core_timer_impl_enable_interrupt(void) {
-    /* Configura priorità 7, sottopriorità 0 */
-    IPC0SET = (1 << _IPC0_CTIP_POSITION) | (0 << _IPC0_CTIS_POSITION);
-    /* Pulisci flag */
-    IFS0CLR = _IFS0_CTIF_MASK;
-    /* Abilita interrupt */
-    IEC0SET = _IEC0_CTIE_MASK;
-        /* Azzera il contatore Count (CP0 $9) per partire da zero */
-    __asm__ volatile (
-        "mtc0 $zero, $9\n"
-    );
+void arch_core_timer_impl_enable_interrupt(void)
+{
+    ArchSysTick *systick = arch_systick_get_instance();
+    arch_systick_enable_interrupt(systick);
 }
 
 #endif

--- a/arch/mips/impl/pic32mx_cpu_impl.S
+++ b/arch/mips/impl/pic32mx_cpu_impl.S
@@ -76,7 +76,7 @@ cpu_context_restore:
     nop
     nop
     
-    mtc0    $zero, $9            # Reset Core Timer Count ($9)
+    //mtc0    $zero, $9            # Reset Core Timer Count ($9)
     ehb
     nop
     nop

--- a/arch/mips/impl/pic32mx_systick.h
+++ b/arch/mips/impl/pic32mx_systick.h
@@ -1,0 +1,35 @@
+/**
+ * @file pic32mx_systick.h
+ * @author Santiago Marino
+ * @year 2026
+ * @brief MIPS PIC32MX concrete definition for system tick timer.
+ * 
+ * Uses the Core Timer (CP0 registers $9 = Count, $11 = Compare).
+ * Counter increments at CPU_HZ / 2.
+ */
+
+#ifndef PIC32MX_SYSTICK_H
+#define PIC32MX_SYSTICK_H
+
+#include <stdint.h>
+#include "../pic32mx470f512h.h"
+
+/* ============================================================================
+ * Core Timer frequency (MIPS specific)
+ * ============================================================================
+ * The Core Timer increments at half the CPU clock speed.
+ * ============================================================================ */
+#define CORE_TIMER_HZ (CPU_HZ / 2)
+
+/**
+ * @brief Concrete definition of ArchSysTick for MIPS PIC32MX.
+ */
+struct ArchSysTick {
+    uint32_t counter;      /* Last read value from CP0 $9 */
+    uint32_t compare;      /* Last read value from CP0 $11 */
+    uint32_t period;       /* Current period in cycles */
+    uint32_t frequency;    /* CORE_TIMER_HZ */
+    int initialized;       /* Initialization flag */
+};
+
+#endif /* PIC32MX_SYSTICK_H */

--- a/arch/mips/impl/pic32mx_systick_impl.c
+++ b/arch/mips/impl/pic32mx_systick_impl.c
@@ -1,0 +1,153 @@
+/**
+ * @file pic32mx_systick_impl.c
+ * @author Santiago Marino
+ * @year 2026
+ * @brief MIPS PIC32MX implementation of system tick timer.
+ */
+
+#include "../../include/arch_systick.h"
+#include "pic32mx_systick.h"
+#include <xc.h>
+#include <stdint.h>
+
+/* ============================================================================
+ * Singleton instance
+ * ============================================================================ */
+static struct ArchSysTick systick_instance = {0};
+
+/* ============================================================================
+ * Helper: read Core Timer Count (CP0 $9)
+ * ============================================================================ */
+static inline uint32_t core_timer_read_count(void)
+{
+    uint32_t count;
+    __asm__ volatile (
+        "mfc0 %0, $9\n"
+        "ehb\n"
+        : "=r" (count)
+    );
+    return count;
+}
+
+/* ============================================================================
+ * Helper: read Core Timer Compare (CP0 $11)
+ * ============================================================================ */
+static inline uint32_t core_timer_read_compare(void)
+{
+    uint32_t compare;
+    __asm__ volatile (
+        "mfc0 %0, $11\n"
+        "ehb\n"
+        : "=r" (compare)
+    );
+    return compare;
+}
+
+/* ============================================================================
+ * Helper: write Core Timer Compare (CP0 $11)
+ * ============================================================================ */
+static inline void core_timer_write_compare(uint32_t value)
+{
+    __asm__ volatile (
+        "mtc0 %0, $11\n"
+        "ehb\n"
+        : : "r" (value)
+    );
+}
+
+/* ============================================================================
+ * Public API implementation
+ * ============================================================================ */
+
+ArchSysTick* arch_systick_get_instance(void)
+{
+    return &systick_instance;
+}
+
+uint32_t arch_systick_read(const ArchSysTick *tick)
+{
+    (void)tick;
+    return core_timer_read_count();
+}
+
+uint32_t arch_systick_get_period(const ArchSysTick *tick)
+{
+    (void)tick;
+    return core_timer_read_compare();
+}
+
+uint32_t arch_systick_get_frequency(const ArchSysTick *tick)
+{
+    if (!tick) return 0;
+    return tick->frequency;
+}
+
+int arch_systick_init(ArchSysTick *tick, uint32_t period_cycles)
+{
+    if (!tick) return -1;
+    
+    tick->frequency = CORE_TIMER_HZ;
+    tick->period = period_cycles;
+    
+    /* Set Compare register - DO NOT reset Count */
+    core_timer_write_compare(period_cycles);
+    
+    tick->counter = 0;
+    tick->compare = period_cycles;
+    tick->initialized = 1;
+    
+    return 0;
+}
+
+void arch_systick_set_period(ArchSysTick *tick, uint32_t period_cycles)
+{
+    if (!tick) return;
+    
+    tick->period = period_cycles;
+    
+    uint32_t current_compare = core_timer_read_compare();
+    core_timer_write_compare(current_compare + period_cycles);
+    tick->compare = current_compare + period_cycles;
+}
+
+void arch_systick_enable_interrupt(ArchSysTick *tick)
+{
+    if (!tick) return;
+    
+    IPC0SET = (1 << _IPC0_CTIP_POSITION);
+    IFS0CLR = (1 << _IFS0_CTIF_POSITION);
+    IEC0SET = (1 << _IEC0_CTIE_POSITION);
+}
+
+void arch_systick_clear_interrupt(ArchSysTick *tick)
+{
+    if (!tick) return;
+    IFS0CLR = (1 << _IFS0_CTIF_POSITION);
+}
+
+void arch_systick_start(ArchSysTick *tick)
+{
+    if (!tick) return;
+    
+    uint32_t count = core_timer_read_count();
+    uint32_t compare = core_timer_read_compare();
+    
+    if (count >= compare) {
+        core_timer_write_compare(count + tick->period);
+    }
+}
+
+void arch_systick_stop(ArchSysTick *tick)
+{
+    if (!tick) return;
+    IEC0CLR = (1 << _IEC0_CTIE_POSITION);
+}
+
+void arch_systick_tick(ArchSysTick *tick)
+{
+    if (!tick || !tick->initialized) return;
+    
+    uint32_t new_compare = core_timer_read_compare() + tick->period;
+    core_timer_write_compare(new_compare);
+    tick->compare = new_compare;
+}

--- a/arch/mips/pic32mx470f512h.h
+++ b/arch/mips/pic32mx470f512h.h
@@ -1,3 +1,27 @@
+#include "impl/pic32mx_cpu.h"
+#include "impl/pic32mx_systick.h"
+
+#ifndef PIC32MX470F512H_H
+#define PIC32MX470F512H_H
+
+/* ============================================================================
+ * CPU frequency - MUST match your board's actual clock speed
+ * ============================================================================
+ * PIC32MX470F512H typical configurations:
+ *   - 80 MHz: 8MHz external crystal + PLL (default)
+ *   - 48 MHz: USB ready
+ *   - 72 MHz: Common alternative
+ * 
+ * Change this according to your hardware configuration.
+ * ============================================================================
+ */
+#ifndef CPU_HZ
+#define CPU_HZ 80000000UL   /* 80 MHz - change if your board is different */
+#endif
+
+
+
+
 #define MEM_RAM_SIZE    131072
 #define ARCH_RAMDISK_BLOCK_SIZE      32
 #define ARCH_RAMDISK_BLOCK_COUNT     1024
@@ -80,3 +104,6 @@
 #define HAS_I2C(mask)  ((ACTIVE_I2C_MASK & (mask)) != 0)
 #define HAS_CORE_TIMER(mask) ((ACTIVE_CORE_TIMER_MASK & (mask)) != 0)
 #define HAS_UART(mask) ((ACTIVE_UART_MASK & (mask)) != 0)
+
+
+#endif

--- a/kernel/scheduler/scheduler.c
+++ b/kernel/scheduler/scheduler.c
@@ -14,8 +14,9 @@
  */
 
 #include "task.h"
-#include "arch/include/arch_cpu.h"
+#include "arch/arch.h"
 #include "arch/arch_core_timer.h"
+#include "arch/include/arch_systick.h"
 #include "kernel/context/task_exit.h"
 #include "kernel/memory/mem_alloc.h"
 #include "kernel/event/event.h"
@@ -24,8 +25,8 @@
 
 extern void cpu_idle(void);
 
-static Task *ready_list = (Task *)0x0;
-Task *current_task = (Task *)0x0;
+static Task *ready_list = (Task *) 0x0;
+Task *current_task = (Task *) 0x0;
 static uint32_t next_task_id = 1;
 uint8_t kernel_stack[KERNEL_STACK];
 
@@ -46,7 +47,7 @@ static void insert_task(Task *task) {
  * Crea un nuovo task
  * -------------------------------------------------------------------------- */
 Task* task_create(void (*entry)(void *), void *arg, uint32_t stack_size) {
-    Task *task = (Task*)mem_alloc(sizeof(Task));
+    Task *task = (Task*) mem_alloc(sizeof (Task));
     if (!task) return NULL;
 
     task->stack = mem_alloc(stack_size);
@@ -54,15 +55,28 @@ Task* task_create(void (*entry)(void *), void *arg, uint32_t stack_size) {
         mem_free(task);
         return NULL;
     }
+
+
+    // ALLOCA IL CONTESTO SEPARATAMENTE
+    task->context = (CpuContext*) mem_alloc(sizeof (CpuContext));
+    if (!task->context) {
+        mem_free(task->stack);
+        mem_free(task);
+        return NULL;
+    }
+
+
     task->stack_size = stack_size;
     task->entry = entry;
     task->arg = arg;
     task->id = next_task_id++;
     task->priv_data = NULL;
+    task->total_cycles = 0;
+    task->last_count = arch_systick_read(arch_systick_get_instance());
 
     /* Prepara lo stack e il contesto CPU */
-    void *stack_top = (uint8_t*)task->stack + stack_size;
-    cpu_context_init(&task->context, entry, arg, stack_top, task_exit_handler);
+    void *stack_top = (uint8_t*) task->stack + stack_size;
+    cpu_context_init(task->context, entry, arg, stack_top, task_exit_handler);
 
     insert_task(task);
     return task;
@@ -88,12 +102,17 @@ void task_destroy_current(void) {
     }
 
     /* Notifica l'evento di terminazione */
-    event_trigger(EVENT_TASK_TERMINATED, (void*)(uintptr_t)current_task->id);
+    event_trigger(EVENT_TASK_TERMINATED, (void*) (uintptr_t) current_task->id);
 
     /* Rilascia la VM (decrementa il contatore) e poi stack e task */
     if (current_task->priv_data) {
-        vm_ref_dec((VMContext*)current_task->priv_data);
+        vm_ref_dec((VMContext*) current_task->priv_data);
     }
+
+    if (current_task->context) {
+        mem_free(current_task->context);
+    }
+
     mem_free(current_task->stack);
     mem_free(current_task);
     current_task = NULL;
@@ -158,14 +177,17 @@ int task_destroy_by_id(uint32_t id) {
     int was_current = (current_task == target);
 
     /* Notifica evento di terminazione */
-    event_trigger(EVENT_TASK_TERMINATED, (void*)(uintptr_t)target->id);
+    event_trigger(EVENT_TASK_TERMINATED, (void*) (uintptr_t) target->id);
 
     /* Rilascia la VM (decrementa contatore) e poi stack e task */
     if (target->priv_data) {
-        vm_ref_dec((VMContext*)target->priv_data);
+        vm_ref_dec((VMContext*) target->priv_data);
     }
     if (target->stack) {
         mem_free(target->stack);
+    }
+    if (target->context) {
+        mem_free(target->context); 
     }
     mem_free(target);
 
@@ -186,6 +208,17 @@ static void switch_to_next(void) {
         cpu_irq_enable();
         return;
     }
+
+    ArchSysTick *systick = arch_systick_get_instance();
+    uint32_t now = arch_systick_read(systick);
+
+    /* Accumula cicli per il task che sta uscendo */
+    if (current_task != NULL) {
+        uint32_t delta = now - current_task->last_count;
+        current_task->total_cycles += delta;
+    }
+
+
     Task *next = ready_list->next;
     if (next == current_task) {
         cpu_irq_enable();
@@ -193,11 +226,16 @@ static void switch_to_next(void) {
     }
     ready_list = next;
     current_task = next;
+
+    /* Imposta last_count per il nuovo task */
+    current_task->last_count = arch_systick_read(systick);
+
+
     if (next == NULL) {
         cpu_irq_enable();
         return;
     }
-    cpu_context_restore(&current_task->context);
+    cpu_context_restore(current_task->context);
 }
 
 void task_yield(void) {
@@ -209,7 +247,7 @@ void timer_callback(uint32_t count, uintptr_t param) {
 }
 
 static void idle_task(void *arg) {
-    (void)arg;
+    (void) arg;
     while (1) {
         cpu_idle();
     }
@@ -218,12 +256,50 @@ static void idle_task(void *arg) {
 void scheduler_init(void) {
     Task *idle = task_create(idle_task, NULL, 1024);
     if (!idle) return;
-    if (ready_list == (Task *)0) {
+    if (ready_list == (Task *) 0) {
         ready_list = idle;
         idle->next = idle;
         current_task = idle;
     } else {
-        current_task = (Task *)0;
+        current_task = (Task *) 0;
     }
     arch_core_timer_enable_interrupt();
+}
+
+
+uint64_t task_get_cycles(uint32_t task_id) {
+    uint32_t flags = cpu_irq_save();
+    
+    /* Cerca il task nella lista */
+    Task *curr = ready_list;
+    if (curr) {
+        do {
+            if (curr->id == task_id) {
+                uint64_t cycles = curr->total_cycles;
+                cpu_irq_restore(flags);
+                return cycles;
+            }
+            curr = curr->next;
+        } while (curr != ready_list);
+    }
+    
+    cpu_irq_restore(flags);
+    return 0;
+}
+
+
+
+uint64_t task_get_system_cycles(void) {
+    static uint64_t system_cycles = 0;
+    static uint32_t last_system_count = 0;
+    
+    ArchSysTick *systick = arch_systick_get_instance();
+    uint32_t now = arch_systick_read(systick);
+    
+    if (last_system_count != 0) {
+        system_cycles += (now - last_system_count);
+    }
+    last_system_count = now;
+    
+    return system_cycles;
 }

--- a/kernel/scheduler/task.h
+++ b/kernel/scheduler/task.h
@@ -14,8 +14,6 @@
 
 #ifndef TASK_H
 #define TASK_H
-
-#include "../../arch/mips/impl/pic32mx_cpu.h"
 #include "arch/include/arch_cpu.h"
 #include <stdint.h>
 
@@ -31,8 +29,9 @@ extern uint8_t kernel_stack[];
  * una funzione di ingresso, un argomento, un ID univoco, un puntatore
  * a dati privati (es. VMContext) e un puntatore per la lista circolare.
  */
+
 typedef struct Task {
-    CpuContext context;      /**< Contesto CPU salvato (registri) */
+    CpuContext  *context;      /**< Contesto CPU salvato (registri) */
     void *stack;             /**< Base dello stack (indirizzo basso) */
     uint32_t stack_size;     /**< Dimensione dello stack in byte */
     void (*entry)(void *);   /**< Funzione di ingresso del task */
@@ -40,6 +39,10 @@ typedef struct Task {
     uint32_t id;             /**< Identificatore univoco del task */
     void *priv_data;         /**< Dati privati (es. VMContext) per associazione */
     struct Task *next;       /**< Puntatore al prossimo task nella lista circolare */
+    
+        /* CPU usage tracking */
+    uint64_t total_cycles;      // cicli totali eseguiti da questo task
+    uint32_t last_count;        // ultimo valore del Counter letto
 } Task;
 
 /**
@@ -94,5 +97,12 @@ int task_destroy_by_id(uint32_t id);
  * quindi task_yield() non fa nulla. Mantenuta per compatibilità.
  */
 void task_yield(void);
+
+
+
+uint64_t task_get_cycles(uint32_t id);
+
+
+uint64_t task_get_system_cycles(void);
 
 #endif /* TASK_H */

--- a/kernel/vm/kernel_intent_dispatcher.c
+++ b/kernel/vm/kernel_intent_dispatcher.c
@@ -23,19 +23,18 @@
  * @return Risultato dell'operazione (scritto in k0 della VM)
  */
 uint32_t kernel_intent_dispatcher(VMContext *vm) {
-    uint32_t action   = vm->regs.named.v0;
+    uint32_t action = vm->regs.named.v0;
     uint32_t category = vm->regs.named.a0;
-    uint32_t p1       = vm->regs.named.a1;
-    uint32_t p2       = vm->regs.named.a2;
+    uint32_t p1 = vm->regs.named.a1;
+    uint32_t p2 = vm->regs.named.a2;
 
     switch (category) {
         case CAP_SYSTEM:
             if (action == ACTION_LOAD_APP) {
                 /* p1 = offset del binario nella RAM della VM, p2 = dimensione */
                 uint8_t* bin_ptr = vm->ram_buffer + p1;
-                return (uint32_t)kernel_load_app(bin_ptr, p2);
-            }
-            else if (action == ACTION_STOP) {
+                return (uint32_t) kernel_load_app(bin_ptr, p2);
+            } else if (action == ACTION_STOP) {
                 /* p1 = ID del task da terminare */
                 int ret = task_destroy_by_id(p1);
                 return (ret == 0) ? 0 : 0xFFFFFFFF;
@@ -44,11 +43,11 @@ uint32_t kernel_intent_dispatcher(VMContext *vm) {
 
         case CAP_LOGGING:
             if (action == ACTION_SEND) {
-                char* msg = (char*)(vm->ram_buffer + p1);
+                char* msg = (char*) (vm->ram_buffer + p1);
                 return handle_logging_service(action, msg, 0, 0);
             } else if (action == ACTION_RECEIVE) {
                 uint8_t* buf = vm->ram_buffer + p1;
-                return handle_logging_service(action, (char*)buf, p2, 0);
+                return handle_logging_service(action, (char*) buf, p2, 0);
             }
             return 0xFFFFFFFF;
 
@@ -58,7 +57,17 @@ uint32_t kernel_intent_dispatcher(VMContext *vm) {
         case CAP_STORAGE:
             return handle_storage_service(action, p1, p2, vm->ram_buffer);
 
+
+        case CAP_MONITOR:
+            if (action == ACTION_GET_CPU_USAGE) {
+                /* p1 = task_id */
+                uint64_t cycles = task_get_cycles(p1);
+                /* Restituisce i cicli (split in due registri? o 32 bit) */
+                return (uint32_t) (cycles & 0xFFFFFFFF);
+            }
+            return 0xFFFFFFFF;
+
         default:
-            return 0xFFFFFFFF;   /* Categoria non supportata o non autorizzata */
+            return 0xFFFFFFFF; /* Categoria non supportata o non autorizzata */
     }
 }

--- a/kernel/vm/vm_types.h
+++ b/kernel/vm/vm_types.h
@@ -47,7 +47,8 @@ typedef enum {
     CAP_LOGGING = (1 << 1),   /**< Console (input/output testuale) */
     CAP_SENSORS = (1 << 2),   /**< Lettura sensori simulati */
     CAP_STORAGE = (1 << 3),   /**< Filesystem (create, read, write, delete) */
-    CAP_COMPILER = (1 << 4)   /**< Assemblatore residente (non ancora implementato) */
+    CAP_COMPILER = (1 << 4),   /**< Assemblatore residente (non ancora implementato) */
+    CAP_MONITOR  = (1 << 5)
 } IntentCategory;
 
 /**
@@ -65,7 +66,8 @@ typedef enum {
     ACTION_STORAGE_DELETE   = 7,  /**< Cancella un file */
     ACTION_STORAGE_LIST     = 8,  /**< Elenca file (stub) */
     ACTION_RECEIVE          = 9,  /**< Riceve dati dall'esterno (es. lettura console) */
-    ACTION_ASSEMBLE         = 10  /**< Assembla un file sorgente (non implementato) */
+    ACTION_ASSEMBLE         = 10,  /**< Assembla un file sorgente (non implementato) */
+    ACTION_GET_CPU_USAGE    = 11 
 } IntentAction;
 
 /**


### PR DESCRIPTION
- Initialize CPU tracking in task_create() with arch_systick_read()
- Accumulate cycles delta in switch_to_next() on each context switch
- Fix Core Timer ISR: increment Compare instead of resetting Counter
- Add arch_systick abstraction layer (arch_systick.h, pic32mx_systick.h)
- Implement arch_systick_tick() to increment Compare by period
- Remove mtc0 $zero, $9 from cpu_context_restore (was resetting Count)
- Add CAP_MONITOR (32) and ACTION_GET_CPU_USAGE (11) for VM access
- Expose task_get_cycles() via VCALL for userspace monitoring

Closes #5